### PR TITLE
feat: add dns config and rule sync workflow

### DIFF
--- a/.github/workflows/sync-rules.yml
+++ b/.github/workflows/sync-rules.yml
@@ -1,0 +1,27 @@
+name: Sync Rules
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Download rule sets
+        run: |
+          bash scripts/update_rules.sh
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add rules/
+          git commit -m "chore: sync rules" || echo "No changes"
+
+      - name: Push changes
+        run: git push

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # ACL4SSR
+
+Custom Clash subscription configuration with locally maintained rule sets.
+
+## Syncing rule sets
+
+The repository uses a GitHub Actions workflow (`sync-rules.yml`) to
+automatically download upstream rule files into the `rules/` directory.
+These files are fetched according to `scripts/update_rules.sh` and
+committed back to the repository on a daily schedule.
+
+## DNS configuration
+
+`clash.ini` now includes a `dns` section that enables fake-IP mode and
+defines both domestic and fallback DNS resolvers.

--- a/clash.ini
+++ b/clash.ini
@@ -10,32 +10,32 @@
 ;增强国外GFW：不支持
 ;多国家分组：支持港/日/美
 
-ruleset=🎯 全球直连,https://raw.githubusercontent.com/cmliu/ACL4SSR/refs/heads/main/Clash/CFnat.list
-ruleset=🎯 全球直连,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/LocalAreaNetwork.list
-ruleset=🎯 全球直连,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/UnBan.list
-ruleset=🛑 全球拦截,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/BanAD.list
-ruleset=🍃 应用净化,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/BanProgramAD.list
-ruleset=🍃 应用净化,https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/adobe.list
-ruleset=🍃 应用净化,https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/IDM.list
-ruleset=📢 谷歌FCM,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/GoogleFCM.list
-ruleset=🎯 全球直连,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/GoogleCN.list
-ruleset=🎯 全球直连,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/SteamCN.list
-ruleset=Ⓜ️ 微软服务,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Microsoft.list
-ruleset=🍎 苹果服务,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Apple.list
-ruleset=📲 电报信息,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Telegram.list
-ruleset=🤖 OpenAi,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/OpenAi.list
-ruleset=🤖 OpenAi,https://raw.githubusercontent.com/juewuy/ShellClash/master/rules/ai.list
-ruleset=🤖 OpenAi,https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/Copilot.list
-ruleset=🤖 OpenAi,https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/GithubCopilot.list
-ruleset=🤖 OpenAi,https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/Claude.list
-ruleset=📹 油管视频,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/YouTube.list
-ruleset=🎥 奈飞视频,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Netflix.list
-ruleset=🌍 国外媒体,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ProxyMedia.list
-ruleset=🌍 国外媒体,https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/Emby.list
-ruleset=🚀 节点选择,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ProxyLite.list
-ruleset=🚀 节点选择,https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/CMBlog.list
-ruleset=🎯 全球直连,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ChinaDomain.list
-ruleset=🎯 全球直连,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ChinaCompanyIp.list
+ruleset=🎯 全球直连,rules/CFnat.list
+ruleset=🎯 全球直连,rules/LocalAreaNetwork.list
+ruleset=🎯 全球直连,rules/UnBan.list
+ruleset=🛑 全球拦截,rules/BanAD.list
+ruleset=🍃 应用净化,rules/BanProgramAD.list
+ruleset=🍃 应用净化,rules/adobe.list
+ruleset=🍃 应用净化,rules/IDM.list
+ruleset=📢 谷歌FCM,rules/GoogleFCM.list
+ruleset=🎯 全球直连,rules/GoogleCN.list
+ruleset=🎯 全球直连,rules/SteamCN.list
+ruleset=Ⓜ️ 微软服务,rules/Microsoft.list
+ruleset=🍎 苹果服务,rules/Apple.list
+ruleset=📲 电报信息,rules/Telegram.list
+ruleset=🤖 OpenAi,rules/OpenAi.list
+ruleset=🤖 OpenAi,rules/ai.list
+ruleset=🤖 OpenAi,rules/Copilot.list
+ruleset=🤖 OpenAi,rules/GithubCopilot.list
+ruleset=🤖 OpenAi,rules/Claude.list
+ruleset=📹 油管视频,rules/YouTube.list
+ruleset=🎥 奈飞视频,rules/Netflix.list
+ruleset=🌍 国外媒体,rules/ProxyMedia.list
+ruleset=🌍 国外媒体,rules/Emby.list
+ruleset=🚀 节点选择,rules/ProxyLite.list
+ruleset=🚀 节点选择,rules/CMBlog.list
+ruleset=🎯 全球直连,rules/ChinaDomain.list
+ruleset=🎯 全球直连,rules/ChinaCompanyIp.list
 ;ruleset=🎯 全球直连,[]GEOIP,LAN
 ruleset=🎯 全球直连,[]GEOIP,CN
 ruleset=🐟 漏网之鱼,[]FINAL
@@ -61,3 +61,38 @@ custom_proxy_group=🇺🇸 美国`load-balance`(美|San Jose|波特兰|达拉�
 
 enable_rule_generator=true
 overwrite_original_rules=true
+
+dns:
+  enable: true
+  listen: 0.0.0.0:53
+  ipv6: false
+
+  enhanced-mode: fake-ip
+  fake-ip-range: 198.18.0.1/16
+  fake-ip-filter:
+    - '*.lan'
+    - '*.local'
+    - 'localhost'
+    - '*.direct'
+
+  nameserver:
+    - 223.5.5.5
+    - 119.29.29.29
+    - 180.76.76.76
+
+  fallback:
+    - https://1.1.1.1/dns-query
+    - https://8.8.8.8/dns-query
+    - https://9.9.9.9/dns-query
+
+  fallback-filter:
+    geoip: true
+    geoip-code: CN
+    ipcidr:
+      - 240.0.0.0/4
+    domain:
+      - '+.google.com'
+      - '+.facebook.com'
+      - '+.youtube.com'
+      - '+.twitter.com'
+      - '+.github.com'

--- a/scripts/update_rules.sh
+++ b/scripts/update_rules.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RULE_DIR="rules"
+mkdir -p "$RULE_DIR"
+
+declare -A RULES=(
+  [CFnat.list]="https://raw.githubusercontent.com/cmliu/ACL4SSR/refs/heads/main/Clash/CFnat.list"
+  [LocalAreaNetwork.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/LocalAreaNetwork.list"
+  [UnBan.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/UnBan.list"
+  [BanAD.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/BanAD.list"
+  [BanProgramAD.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/BanProgramAD.list"
+  [adobe.list]="https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/adobe.list"
+  [IDM.list]="https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/IDM.list"
+  [GoogleFCM.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/GoogleFCM.list"
+  [GoogleCN.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/GoogleCN.list"
+  [SteamCN.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/SteamCN.list"
+  [Microsoft.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Microsoft.list"
+  [Apple.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Apple.list"
+  [Telegram.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Telegram.list"
+  [OpenAi.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/OpenAi.list"
+  [ai.list]="https://raw.githubusercontent.com/juewuy/ShellClash/master/rules/ai.list"
+  [Copilot.list]="https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/Copilot.list"
+  [GithubCopilot.list]="https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/GithubCopilot.list"
+  [Claude.list]="https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/Claude.list"
+  [YouTube.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/YouTube.list"
+  [Netflix.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Netflix.list"
+  [ProxyMedia.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ProxyMedia.list"
+  [Emby.list]="https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/Emby.list"
+  [ProxyLite.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ProxyLite.list"
+  [CMBlog.list]="https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/CMBlog.list"
+  [ChinaDomain.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ChinaDomain.list"
+  [ChinaCompanyIp.list]="https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ChinaCompanyIp.list"
+)
+
+for file in "${!RULES[@]}"; do
+  url="${RULES[$file]}"
+  echo "Downloading $file"
+  curl -L "$url" -o "$RULE_DIR/$file"
+done


### PR DESCRIPTION
## Summary
- host rule lists locally and add workflow to sync them
- include dns configuration for clash

## Testing
- `bash -n scripts/update_rules.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b340e1e0388327bb72dbd39333e1d0